### PR TITLE
ignores tgz files

### DIFF
--- a/teamspeak3/.helmignore
+++ b/teamspeak3/.helmignore
@@ -17,3 +17,4 @@
 .idea/
 *.tmproj
 .vscode/
+*.tgz


### PR DESCRIPTION
Hi, 
thank you for the helm chart. I was trying to deploy it and got an error as the chart was to large. After a short check it turned out the tgz files from the old releases were incoperated into the chart. This change ignores them and makes the chart smaller and deployable again.
