### PR TITLE
Align chart more with latest helm template

### DIFF
--- a/teamspeak3/Chart.yaml
+++ b/teamspeak3/Chart.yaml
@@ -1,6 +1,5 @@
-apiVersion: v1
+apiVersion: v2
 description: teamspeak3 server
-engine: gotpl
 home: http://charts.sandermann.cloud/
 keywords:
 - teamspeak3
@@ -8,6 +7,7 @@ maintainers:
 - email: kevin.sandermann@gmail.com
   name: ksandermann
 name: teamspeak3
+type: application
 sources:
 - https://github.com/ksandermann/helm-charts/blob/master/teamspeak3
 version: 1.0.0

--- a/teamspeak3/templates/_helpers.tpl
+++ b/teamspeak3/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "teamspeak.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "teamspeak.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "teamspeak.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "teamspeak.labels" -}}
+helm.sh/chart: {{ include "teamspeak.chart" . }}
+{{ include "teamspeak.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "teamspeak.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "teamspeak.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/teamspeak3/templates/configmap.yaml
+++ b/teamspeak3/templates/configmap.yaml
@@ -1,9 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: teamspeak
+  name: {{ include "teamspeak.fullname" . }}
+  labels:
+    {{- include "teamspeak.labels" . | nindent 4 }}
 data:
+  {{- if .Values.configs.allowlist }}
   allowlist.txt: |
     {{- range .Values.configs.allowlist }}
     {{ . }}
     {{- end }}
+  {{- end }}

--- a/teamspeak3/templates/deployment.yaml
+++ b/teamspeak3/templates/deployment.yaml
@@ -1,20 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "teamspeak.fullname" . }}
   labels:
-    app: teamspeak
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "teamspeak.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: teamspeak
-      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-      release: {{ .Release.Name }}
-      heritage: {{ .Release.Service }}
+      {{- include "teamspeak.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -23,26 +17,27 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: teamspeak
-        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        release: {{ .Release.Name }}
-        heritage: {{ .Release.Service }}
+        {{- include "teamspeak.selectorLabels" . | nindent 8 }}
     spec:
-    {{- with .Values.nodeSelector }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: teamspeak-server
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         {{- range .Values.voicePorts }}
@@ -56,7 +51,7 @@ spec:
             protocol: TCP
         {{- end }}
         resources:
-{{ toYaml .Values.resources | indent 12 }}
+          {{- toYaml .Values.resources | nindent 12 }}
         env:
           - name: TS3SERVER_LICENSE
             value: accept

--- a/teamspeak3/templates/pvc.yaml
+++ b/teamspeak3/templates/pvc.yaml
@@ -2,12 +2,9 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-data
+  name: {{ include "teamspeak.fullname" . }}
   labels:
-    app: teamspeak
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "teamspeak.labels" . | nindent 4 }}
   {{- if .Values.persistence.annotations }}
   annotations:
 {{ toYaml .Values.persistence.annotations | indent 4 }}

--- a/teamspeak3/templates/service-tcp.yaml
+++ b/teamspeak3/templates/service-tcp.yaml
@@ -2,12 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-tcp
+  name: {{ include "teamspeak.fullname" . }}-tcp
   labels:
-    app: teamspeak
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "teamspeak.labels" . | nindent 4 }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ tpl (toYaml .Values.service.annotations) . | indent 4 }}
@@ -31,6 +28,5 @@ spec:
     protocol: TCP
     targetPort: 10011
   selector:
-    app: teamspeak
-    release: {{ .Release.Name }}
+    {{- include "teamspeak.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/teamspeak3/templates/service.yaml
+++ b/teamspeak3/templates/service.yaml
@@ -1,12 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "teamspeak.fullname" . }}
   labels:
-    app: teamspeak
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "teamspeak.labels" . | nindent 4 }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ tpl (toYaml .Values.service.annotations) . | indent 4 }}
@@ -41,5 +38,4 @@ spec:
       protocol: UDP
     {{- end}}
   selector:
-    app: teamspeak
-    release: {{ .Release.Name }}
+    {{- include "teamspeak.selectorLabels" . | nindent 4 }}

--- a/teamspeak3/values.yaml
+++ b/teamspeak3/values.yaml
@@ -1,10 +1,15 @@
 image:
   repository: teamspeak
-  tag: 3.13.7
-  pullPolicy: Always
-  ## Secret must be manually created in the namespace.
-  # pullSecret: "nexus-pull-secret"
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
 podAnnotations: {}
+
 ## only NodePort and LoadBalancer supported, as this is UDP traffic
 service:
   type: LoadBalancer


### PR DESCRIPTION
this is a follow-up to #14 

As I mentioned there, upgrading the helm chart wasn't possible without manual intervention since immutable fields changed. I looked at helm generates when you create a new chart and updated this chart to be more in line with that.

in particular: they differentiate between "labels" and "selectorLabels", the latter of which does not contain values that are subject to change.

I made the metadata consistent between all objects. For users of persistence using PVCs (including myself) manual steps will be necessary since the name changed. Alternatively I could introduce an option to override the PVC name.