### PR TITLE
Allow configuring the externalTrafficPolicy

### DIFF
--- a/teamspeak3/templates/service-tcp.yaml
+++ b/teamspeak3/templates/service-tcp.yaml
@@ -18,6 +18,7 @@ spec:
   externalIPs:
   {{- toYaml .Values.service.externalIPs | nindent 6 }}
   {{- end }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   ports:
   - name: teamspeak-filetransfer
     port: 30033

--- a/teamspeak3/templates/service.yaml
+++ b/teamspeak3/templates/service.yaml
@@ -17,6 +17,7 @@ spec:
   externalIPs:
   {{- toYaml .Values.service.externalIPs | nindent 6 }}
   {{- end }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   ports:
     {{- range .Values.voicePorts }}
     - targetPort: {{ .containerPort }}

--- a/teamspeak3/values.yaml
+++ b/teamspeak3/values.yaml
@@ -27,6 +27,7 @@ service:
   ## known anotations:
   ## MetalLB - metallb.universe.tf/allow-shared-ip: [string]
   ## Azure CPI LB - service.beta.kubernetes.io/azure-load-balancer-mixed-protocols: [bool] (Not tested)
+  externalTrafficPolicy: Cluster
 
   tcp:
     enabled: false


### PR DESCRIPTION
I use MetalLB with BGP to get traffic to the correct node, so I'd like to use `externalTrafficPolicy: Local` to be able to see true client IPs.